### PR TITLE
Fixed copying edited channel posts

### DIFF
--- a/src/handlers/channel.py
+++ b/src/handlers/channel.py
@@ -24,17 +24,33 @@ def create_handlers() -> list:
 async def post(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """When new post appeares on the channel."""
     tools.log('post')
-    copy = await update.channel_post.copy(
-        settings.CHAT_ID, message_thread_id=settings.CHANNEL_THREAD_ID)
-    context.chat_data.setdefault('channel-thread', {})[update.channel_post.id] = copy.message_id
+    if update.channel_post.text or update.channel_post.caption:
+        copy = await update.channel_post.copy(
+            settings.CHAT_ID, message_thread_id=settings.CHANNEL_THREAD_ID)
+        context.chat_data['channel-thread'][update.channel_post.id] = copy.message_id
+    elif update.channel_post.pinned_message:
+        message_to_pin_id = context.chat_data['channel-thread'].setdefault(
+            update.channel_post.pinned_message.id, None)
+        if not message_to_pin_id:
+            tools.log(f'pinned message is missing from the index')
+            return
+        await context.bot.pin_chat_message(settings.CHAT_ID, message_to_pin_id)
 
 
 async def edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """When a post is edited on the channel."""
     tools.log('edit')
-    copied_message_id = context.chat_data.setdefault('channel-thread', {}).setdefault(
+    copied_message_id = context.chat_data['channel-thread'].setdefault(
         update.edited_channel_post.id, None)
     if not copied_message_id:
+        tools.log(f'message is missing from the index')
         return
-    await context.bot.edit_message_text(
-        update.edited_channel_post.text_markdown, settings.CHAT_ID, copied_message_id)
+    if update.edited_channel_post.text:
+        await context.bot.edit_message_text(
+            update.edited_channel_post.text, chat_id=settings.CHAT_ID, message_id=copied_message_id,
+            entities=update.edited_channel_post.entities, parse_mode=None)
+    if update.edited_channel_post.caption:
+        await context.bot.edit_message_caption(
+            chat_id=settings.CHAT_ID, message_id=copied_message_id,
+            caption=update.edited_channel_post.caption,
+            caption_entities=update.edited_channel_post.caption_entities, parse_mode=None)

--- a/src/init.py
+++ b/src/init.py
@@ -31,6 +31,8 @@ async def post_init(app: Application) -> None:
                     welcome.WELCOME_TIMEOUT_JOB, job_params['data'])
             case _:
                 pass
+    channel = await app.bot.get_chat(settings.CHANNEL_USERNAME)
+    app.chat_data[channel.id].setdefault('channel-thread', {})
 
 
 def add_handlers(app: Application) -> None:


### PR DESCRIPTION
The formatting entities (Markdown) are transferred now too.
The edited post with a photo (captioned post) is now transferred too (fixes #20).
Pinning messages is transferred too (fixes #18).
Unpinning is still needed to be fixed.